### PR TITLE
Examples: Update assert helpers

### DIFF
--- a/example/cycle/test/helpers.js
+++ b/example/cycle/test/helpers.js
@@ -13,7 +13,8 @@ export function assertSourcesSinks(sources, sinks, main, done, timeOpts = {}) {
       if (typeof sourceOpts[firstKey] === 'function') {
         obj = {
           [sourceKey]: {
-            [firstKey]: () => Time.diagram(diagram, sourceOpts[firstKey]())
+            [firstKey]: (...args) =>
+              Time.diagram(diagram, sourceOpts[firstKey](...args)),
           }
         }
       } else {


### PR DESCRIPTION
Pass arguments to the function value of sourceOpts. 
It is useful for the `http` category selection use case:

```js
sources.HTTP.select('category')
```